### PR TITLE
Fix lowercase constants:

### DIFF
--- a/vda5050_msgs/msg/Error.msg
+++ b/vda5050_msgs/msg/Error.msg
@@ -8,5 +8,5 @@ string error_level                             # Enum {warning, fatal} warning: 
                                               # intervention required (e.g. laser scanner is contaminated)
 
 # Enums for error_level
-string WARNING="warning"
-string FATAL="fatal"
+string WARNING="WARNING"
+string FATAL="FATAL"

--- a/vda5050_msgs/msg/SafetyState.msg
+++ b/vda5050_msgs/msg/SafetyState.msg
@@ -1,12 +1,12 @@
 string e_stop           # Enum {autoAck, manual, remote, none} Acknowledge-Type of eStop:
                         # autoAck: autoacknowledgeable e-stop is activated e.g. by bumper or protective field
-                        # manual: e-stop has to be acknowledged manually at the vehicle 
+                        # manual: e-stop has to be acknowledged manually at the vehicle
                         # remote: facility estop has to be acknowledged remotely 
                         # none: no e-stop activated
 bool field_violation    # Protective field violation. True: field is violated False: field is not violated
 
 # Enums for eStop
-string AUTO_ACK="autoAck"
-string MANUAL="manual"
-string REMOTE="remote"
-string NONE="none"
+string AUTO_ACK="AUTOACK"
+string MANUAL="MANUAL"
+string REMOTE="REMOTE"
+string NONE="NONE"


### PR DESCRIPTION
# Problem
VDA5050 ROS2 Error.msg and SafetyState.msg contains constants that are not Uppercase, leading to validation errors.

# Solution
Fix lowercase constants.